### PR TITLE
fix Javascript CDN url

### DIFF
--- a/docs/clients/javascript.md
+++ b/docs/clients/javascript.md
@@ -19,7 +19,7 @@ npm i flagsmith --save
 ### Via JavaScript CDN
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/flagsmith/lib/index.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/flagsmith/index.js"></script>
 ```
 
 ### NPM for React Native


### PR DESCRIPTION
The Javascript CDN URL on the Javascript/React Native client [page](https://docs.flagsmith.com/clients/javascript/) is broken.

This is the URL currently: [https://cdn.jsdelivr.net/npm/flagsmith/lib/index.js](https://cdn.jsdelivr.net/npm/flagsmith/lib/index.js)
This is the correct URL: [https://cdn.jsdelivr.net/npm/flagsmith/index.js](https://cdn.jsdelivr.net/npm/flagsmith/index.js) (no `/lib`)