### PR TITLE
Add tip for targeting identities when using local evaluation

### DIFF
--- a/docs/clients/overview.md
+++ b/docs/clients/overview.md
@@ -101,3 +101,10 @@ running in `Local Evaluation` mode.
 
 The benefit of running in Local Evaluation mode is that you can process flag evaluations much more efficiently as they
 are all computed locally.
+
+:::tip
+
+In circumstances where you need to target a specific identity, you can do this by creating a segment to target that
+specific user and subsequently adding a segment override for that segment.
+
+:::


### PR DESCRIPTION
As discussed with Matt A, I've added a workaround solution for people that _need_ to target a specific identity when using local evaluation. 