### PR TITLE
Fix documentation for nodejs client snippet

### DIFF
--- a/docs/clients/server-side.md
+++ b/docs/clients/server-side.md
@@ -989,7 +989,7 @@ const flagsmith = new Flagsmith({
     depending on if you are using Local or Remote Evaluation
     Required.
     */
-    '<FLAGSMITH_ENVIRONMENT_KEY>',
+    environmentKey: '<FLAGSMITH_ENVIRONMENT_KEY>',
 
     /*
     Controls which mode to run in; local or remote evaluation.


### PR DESCRIPTION
Added the "environmentKey" key to the nodejs snippet to make it more copy pastable