### PR TITLE
docs: fix tiny typo in example for react provider

### DIFF
--- a/docs/clients/client-side/react.md
+++ b/docs/clients/client-side/react.md
@@ -54,7 +54,7 @@ export function AppRoot() {
   }} flagsmith={flagsmith}>
     {...}
   </FlagsmithProvider>
-);
+};
 ```
 
 Providing options to the Flagsmith provider will initialise the client, the API reference for these options can be found


### PR DESCRIPTION
Thanks for this great project and the nice doc!