### PR TITLE
Fix. Properties name and key should be under databaseExternal.urlFromExistingSecret

### DIFF
--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -294,8 +294,8 @@ The following table lists the configurable parameters of the chart and their def
 | `databaseExternal.username`                        |                                                                |                                |
 | `databaseExternal.password`                        |                                                                |                                |
 | `databaseExternal.urlFromExistingSecret.enabled`   | Reference an existing secret containing the database URL       |                                |
-| `databaseExternal.name`                            | Name of referenced secret                                      |                                |
-| `databaseExternal.key`                             | Key within the referenced secrt to use                         |                                |
+| `databaseExternal.urlFromExistingSecret.name`      | Name of referenced secret                                      |                                |
+| `databaseExternal.urlFromExistingSecret.key`       | Key within the referenced secrt to use                         |                                |
 | `influxdb.enabled`                                 |                                                                | `true`                         |
 | `influxdb.nameOverride`                            |                                                                | `influxdb`                     |
 | `influxdb.image.repository`                        | docker image repository for influxdb                           | `quay.io/influxdb/influxdb`    |

--- a/versioned_docs/version-v1.0/deployment/kubernetes.md
+++ b/versioned_docs/version-v1.0/deployment/kubernetes.md
@@ -272,8 +272,8 @@ The following table lists the configurable parameters of the chart and their def
 | `databaseExternal.username`                        |                                                                |                                |
 | `databaseExternal.password`                        |                                                                |                                |
 | `databaseExternal.urlFromExistingSecret.enabled`   | Reference an existing secret containing the database URL       |                                |
-| `databaseExternal.name`                            | Name of referenced secret                                      |                                |
-| `databaseExternal.key`                             | Key within the referenced secrt to use                         |                                |
+| `databaseExternal.urlFromExistingSecret.name`      | Name of referenced secret                                      |                                |
+| `databaseExternal.urlFromExistingSecret.key`       | Key within the referenced secrt to use                         |                                |
 | `influxdb.enabled`                                 |                                                                | `true`                         |
 | `influxdb.nameOverride`                            |                                                                | `influxdb`                     |
 | `influxdb.image.repository`                        | docker image repository for influxdb                           | `quay.io/influxdb/influxdb`    |


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) or manually with
      `npx pretty-quick` to check linting
- [x] I have filled in the "Changes" section below?

## Changes

Substitute `databaseExternal.name` with `databaseExternal.urlFromExistingSecret.name`
Substitute `databaseExternal.key` with `databaseExternal.urlFromExistingSecret.key`

This properties should be under `urlFromExistingSecret`. I attempted a helm install with them as per the current docs and my command file. After setting them up correctly, everything ran smoothly.

They are also correctly referenced in the same [docs page](https://docs.flagsmith.com/deployment/kubernetes#external-database-configuration)
