### PR TITLE
Substitute API_URL config with correct FLAGSMITH_API_URL

### DIFF
--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -58,8 +58,8 @@ Then, once any out-of-cluster DNS or CDN changes have been applied, access `http
 #### In a cluster that has an ingress controller, using separate ingresses for frontend and api
 
 Set the following values for flagsmith, with changes as needed to accommodate your ingress controller, and any
-associated DNS changes. Also, set the `API_URL` env-var such that the URL is reachable from a browser accessing the
-frontend.
+associated DNS changes. Also, set the `FLAGSMITH_API_URL` env-var such that the URL is reachable from a browser
+accessing the frontend.
 
 Eg:
 
@@ -81,7 +81,7 @@ ingress:
 
 frontend:
  extraEnv:
-  API_URL: 'https://flagsmith.[MYDOMAIN]/api/v1/'
+  FLAGSMITH_API_URL: 'https://flagsmith.[MYDOMAIN]/api/v1/'
 ```
 
 Then, once any out-of-cluster DNS or CDN changes have been applied, access `https://flagsmith.[MYDOMAIN]` in a browser.


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) or manually with
      `npx pretty-quick` to check linting
- [x] I have filled in the "Changes" section below?

## Changes
The [Kubernetes](https://docs.flagsmith.com/deployment/kubernetes#port-forwarding) section of the docs is incorrect when referring to the env variable `API_URL`, which is correctly referenced in the [Frontend](https://docs.flagsmith.com/deployment/locally-frontend#environment-variables) section
