### PR TITLE
fix: broken link to jmeter tests

### DIFF
--- a/docs/enterprise-edition.md
+++ b/docs/enterprise-edition.md
@@ -302,7 +302,7 @@ LDAP_AUTH_USER_FIELDS=username=sAMAccountName,email=mail,first_name=givenName,la
 
 There are [JMeter](https://jmeter.apache.org/) tests avaiable in our public repo on Github:
 
-https://github.com/Flagsmith/flagsmith/tree/main/jmeter-tests
+https://github.com/Flagsmith/flagsmith/tree/main/api/jmeter-tests
 
 ### wrk
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) or manually with
      `npx pretty-quick` to check linting
- [x] I have filled in the "Changes" section below?

## Changes

This PR will fix the broken link to jmeter tests from [enterprise-edition.md](https://github.com/Flagsmith/flagsmith-docs/blob/main/docs/enterprise-edition.md) file
