### PR TITLE
Add ENABLE_ADMIN_ACCESS_USER_PASS env var to django-admin

### DIFF
--- a/docs/deployment/django-admin.md
+++ b/docs/deployment/django-admin.md
@@ -17,8 +17,12 @@ setting up the platform or via the database. If you're just starting out, you ca
 [here](/deployment/locally-api#Initialising), otherwise, you need to set the `is_staff` and `is_superuser` flags against
 any of the users in your database.
 
-Once you have a user, you can access the django admin pages at `/admin`. You will be prompted to log in with the
+Once you have a user, you can access the django admin pages at `/admin/`. You will be prompted to log in with the
 credentials of any of your super users.
+
+:::info If the login page is only showing the option to 'Log in using SSO' then you may need to set the
+`ENABLE_ADMIN_ACCESS_USER_PASS` environment variable. See
+[this list](http://localhost:3000/deployment/locally-api#application-environment-variables) for more information. :::
 
 ## Admin Pages
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/locally-api#pre-commit) or manually with
      `npx pretty-quick` to check linting
- [x] I have filled in the "Changes" section below?

## Changes

Add documentation to django-admin page to allow people to use username / password to access django admin. 
