### PR TITLE
Ditch data fixtures for local API setup

### DIFF
--- a/docs/deployment/hosting/locally-api.md
+++ b/docs/deployment/hosting/locally-api.md
@@ -23,12 +23,6 @@ python manage.py runserver --nostatic
 You can now visit `http://<your-server-domain:8000>/api/v1/users/config/init/` to create an initial Superuser and
 provide DNS settings for your installation.
 
-If you want to load some sample data into your database:
-
-```bash
-python manage.py loaddata app/fixtures/init_data.yaml
-```
-
 Note: if you're running on on MacOS and you find some issues installing the dependencies (specifically around pyre2),
 you may need to run the following:
 

--- a/versioned_docs/version-v1.0/deployment/locally-api.md
+++ b/versioned_docs/version-v1.0/deployment/locally-api.md
@@ -22,12 +22,6 @@ python manage.py runserver --nostatic
 You can now visit `http://<your-server-domain:8000>/api/v1/users/config/init/` to create an initial Superuser and
 provide DNS settings for your installation.
 
-If you want to load some sample data into your database:
-
-```bash
-python manage.py loaddata app/fixtures/init_data.yaml
-```
-
 Note: if you're running on on MacOS and you find some issues installing the dependencies (specifically around pyre2),
 you may need to run the following:
 


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [x] I have run [`pre-commit`](https://docs.flagsmith.com/deployment/hosting/locally-api#pre-commit) or manually with
      `npx pretty-quick` to check linting
- [x] I have filled in the "Changes" section below?

## Changes

Remove deprecated data fixtures usage. This is currently broken and hasn't been used by anyone for a while.